### PR TITLE
Update epay_referral.php

### DIFF
--- a/epay_referral.php
+++ b/epay_referral.php
@@ -1,6 +1,6 @@
 <?php
 require_once "maincore.php";
-$wallet=json_decode(urldecode($_GET['wallet']));
+$wallet=json_decode(urldecode($_GET['wallet']), true);
 $query=implode(',',$wallet);
 $lastweek=strtotime('-7 days');
 $db->queryres("select count(user_id) as cus from tbl_user where reffer_id


### PR DESCRIPTION
In installing your faucet script on my server, I notice a small bug in epay_referral.php. If you do not indicate true as second parameter of json_encode, you do not generate an associative array thus implode cannot provide a result and will be always NULL (https://stackoverflow.com/questions/5164404/json-decode-to-array).